### PR TITLE
Fix duplicate output hatches when using HatchMIHookContext#registerHatches

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
@@ -45,13 +45,13 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 
 	@SafeVarargs
-	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-									Consumer<BlockBehaviour.Properties> overrideProperties,
-									boolean defaultMineableTags,
-									HatchFactory factory,
-									boolean input,
-									Consumer<BlockEntityType<?>>... extraRegistrators)
+	private void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+                               Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+                               Consumer<BlockBehaviour.Properties> overrideProperties,
+                               boolean defaultMineableTags,
+                               HatchFactory factory,
+                               boolean input,
+                               Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, modifyBlock, overrideProperties, defaultMineableTags, (bep) -> factory.create(bep, input, hook.id(id)), extraRegistrators);
 		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, true, false, true, false);

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
@@ -43,6 +43,19 @@ public final class HatchMIHookContext extends MIHookContext
 	{
 		void apply(T value, boolean input);
 	}
+
+	@SafeVarargs
+	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+									Consumer<BlockBehaviour.Properties> overrideProperties,
+									boolean defaultMineableTags,
+									HatchFactory factory,
+									boolean input,
+									Consumer<BlockEntityType<?>>... extraRegistrators)
+	{
+		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, modifyBlock, overrideProperties, defaultMineableTags, (bep) -> factory.create(bep, input, hook.id(id)), extraRegistrators);
+		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, true, false, true, false);
+	}
 	
 	@SafeVarargs
 	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
@@ -52,8 +65,7 @@ public final class HatchMIHookContext extends MIHookContext
 									HatchFactory factory,
 									Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
-		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, modifyBlock, overrideProperties, defaultMineableTags, (bep) -> factory.create(bep, false, hook.id(id)), extraRegistrators);
-		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, true, false, true, false);
+		registerHatch(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, defaultMineableTags, factory, false, extraRegistrators);
 	}
 	
 	@SafeVarargs
@@ -91,7 +103,7 @@ public final class HatchMIHookContext extends MIHookContext
 					machineId, machineEnglishName, overlayFolder, casing,
 					modifyBlock != null ? (holder) -> modifyBlock.apply(holder, input) : null,
 					overrideProperties != null ? (properties) -> overrideProperties.apply(properties, input) : null,
-					defaultMineableTags, factory, extraRegistrators
+					defaultMineableTags, factory, input, extraRegistrators
 			);
 		}
 	}


### PR DESCRIPTION
When using `HatchMIHookContext#registerHatches`, the overloaded `#registerHatch` method is called. However, this method always passes `false` in the `HatchFactory`:

https://github.com/Swedz/tesseract-neoforge/blob/91dea4ec25ec1cfe6c6edd6c7474e152aca6ee9f/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java#L55

Making both Input and Output hatches being registered as output.