### PR TITLE
Add simple machine builder API for making machines instead of excessive overloaded methods

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hack/HackedMachineRegistrationHelper.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hack/HackedMachineRegistrationHelper.java
@@ -30,14 +30,17 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.MapColor;
 import net.swedz.tesseract.neoforge.compat.mi.helper.MachineInventoryHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHookRegistry;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHookTracker;
-import net.swedz.tesseract.neoforge.compat.mi.machine.MachineBlockCreator;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
 import net.swedz.tesseract.neoforge.compat.mi.mixin.accessor.MIMachineRecipeTypesAccessor;
 import net.swedz.tesseract.neoforge.registry.common.CommonLootTableBuilders;
 import net.swedz.tesseract.neoforge.registry.common.CommonModelBuilders;
@@ -60,32 +63,32 @@ import static aztech.modern_industrialization.machines.init.SingleBlockCraftingM
  *
  * <p><b>It is recommended to not use these methods yourself.</b> They are intended for internal use within Tesseract
  * only. If you need to call one of these methods instead of a method in a hook context, there is something missing in
- * the hook context and that should be considered a bug / mistake.</p>
+ * the hook context and that should be considered a bug / mistake. Also, I will change these methods without warning.
+ * :)</p>
  */
 public final class HackedMachineRegistrationHelper
 {
 	/**
 	 * @see MachineRegistrationHelper#registerMachine(String, String, Function, Consumer[])
 	 */
-	@SafeVarargs
 	public static Supplier<BlockEntityType<?>> registerMachine(MIHook hook,
 															   String englishName, String name,
-															   MachineBlockCreator blockCreator,
-															   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-															   Consumer<BlockBehaviour.Properties> overrideProperties,
+															   MachineBlockFactory blockFactory,
+															   MachineBlockHolderModifier holderModifier,
+															   MachineBlockPropertiesModifier overrideProperties,
 															   boolean defaultMineableTags,
-															   Function<BEP, MachineBlockEntity> factory,
-															   Consumer<BlockEntityType<?>>... extraRegistrators)
+															   MachineBlockEntityFactory factory,
+															   MachineBlockRegistrators... extraRegistrators)
 	{
 		MIHookRegistry registry = hook.registry();
 		ResourceLocation id = hook.id(name);
 		
 		AtomicReference<BlockEntityType<?>> bet = new AtomicReference<>();
-		BiFunction<BlockPos, BlockState, MachineBlockEntity> ctor = (pos, state) -> factory.apply(new BEP(bet.get(), pos, state));
+		BiFunction<BlockPos, BlockState, MachineBlockEntity> ctor = (pos, state) -> factory.create(new BEP(bet.get(), pos, state));
 		
 		BlockWithItemHolder<?, ?> blockHolder = new BlockWithItemHolder<>(
 				id, englishName,
-				registry.blockRegistry(), (p) -> blockCreator == null ? new MachineBlock(ctor, p) : blockCreator.create(ctor, p),
+				registry.blockRegistry(), (p) -> blockFactory == null ? new MachineBlock(ctor, p) : blockFactory.create(ctor, p),
 				registry.itemRegistry(), BlockItem::new
 		);
 		blockHolder.item().sorted(registry.sortOrderMachines());
@@ -99,7 +102,7 @@ public final class HackedMachineRegistrationHelper
 				{
 					if(overrideProperties != null)
 					{
-						overrideProperties.accept(properties);
+						overrideProperties.modify(properties);
 					}
 					else
 					{
@@ -123,9 +126,9 @@ public final class HackedMachineRegistrationHelper
 							.customLoader((bmb, exFile) -> new FakedMachineModelBuilder<>(machineModelProperties, bmb, exFile))
 							.end());
 				});
-		if(modifyBlock != null)
+		if(holderModifier != null)
 		{
-			modifyBlock.accept(blockHolder);
+			holderModifier.modify(blockHolder);
 		}
 		blockHolder.register();
 		
@@ -138,9 +141,9 @@ public final class HackedMachineRegistrationHelper
 			
 			bet.set(BlockEntityType.Builder.of(ctor::apply, block).build(null));
 			
-			for(Consumer<BlockEntityType<?>> extraRegistrator : extraRegistrators)
+			for(var extraRegistrator : extraRegistrators)
 			{
-				extraRegistrator.accept(bet.get());
+				extraRegistrator.apply(bet.get());
 			}
 			
 			registry.onBlockEntityRegister(bet.get());
@@ -149,23 +152,21 @@ public final class HackedMachineRegistrationHelper
 		});
 	}
 	
-	@SafeVarargs
 	public static Supplier<BlockEntityType<?>> registerMachine(MIHook hook,
 															   String englishName, String name,
-															   MachineBlockCreator blockCreator,
-															   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-															   Consumer<BlockBehaviour.Properties> overrideProperties,
-															   Function<BEP, MachineBlockEntity> factory,
-															   Consumer<BlockEntityType<?>>... extraRegistrators)
+															   MachineBlockFactory blockCreator,
+															   MachineBlockHolderModifier modifyBlock,
+															   MachineBlockPropertiesModifier overrideProperties,
+															   MachineBlockEntityFactory factory,
+															   MachineBlockRegistrators... extraRegistrators)
 	{
 		return registerMachine(hook, englishName, name, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
 	public static Supplier<BlockEntityType<?>> registerMachine(MIHook hook,
 															   String englishName, String name,
-															   Function<BEP, MachineBlockEntity> factory,
-															   Consumer<BlockEntityType<?>>... extraRegistrators)
+															   MachineBlockEntityFactory factory,
+															   MachineBlockRegistrators... extraRegistrators)
 	{
 		return registerMachine(hook, englishName, name, null, null, null, factory, extraRegistrators);
 	}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
@@ -15,17 +15,20 @@ import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import com.google.common.collect.Lists;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.HatchMachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
 import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 public final class HatchMIHookContext extends MIHookContext
 {
@@ -34,65 +37,72 @@ public final class HatchMIHookContext extends MIHookContext
 		super(hook);
 	}
 	
+	public HatchMachineBuilder builder(String name, String englishName)
+	{
+		return MachineBuilder.hatch(hook, name, englishName);
+	}
+	
+	@Deprecated(forRemoval = true)
 	public interface HatchFactory
 	{
 		HatchBlockEntity create(BEP bep, boolean input, ResourceLocation machineId);
 	}
 	
+	@Deprecated(forRemoval = true)
 	public interface HatchModification<T>
 	{
 		void apply(T value, boolean input);
 	}
 	
-	@SafeVarargs
+	@Deprecated(forRemoval = true)
 	private void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   MachineBlockHolderModifier modifyBlock,
+							   MachineBlockPropertiesModifier overrideProperties,
 							   boolean defaultMineableTags,
 							   HatchFactory factory,
 							   boolean input,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+							   MachineBlockRegistrators... extraRegistrators)
 	{
 		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, null, modifyBlock, overrideProperties, defaultMineableTags, (bep) -> factory.create(bep, input, hook.id(id)), extraRegistrators);
 		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, true, false, true, false);
 	}
 	
-	@SafeVarargs
-	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-									Consumer<BlockBehaviour.Properties> overrideProperties,
-									boolean defaultMineableTags,
-									HatchFactory factory,
-									Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+							  MachineBlockHolderModifier modifyBlock,
+							  MachineBlockPropertiesModifier overrideProperties,
+							  boolean defaultMineableTags,
+							  HatchFactory factory,
+							  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, defaultMineableTags, factory, false, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-									Consumer<BlockBehaviour.Properties> overrideProperties,
-									HatchFactory factory,
-									Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+							  MachineBlockHolderModifier modifyBlock,
+							  MachineBlockPropertiesModifier overrideProperties,
+							  HatchFactory factory,
+							  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-									HatchFactory factory,
-									Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+							  HatchFactory factory,
+							  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									  HatchModification<BlockBehaviour.Properties> overrideProperties,
-									  boolean defaultMineableTags,
-									  HatchFactory factory,
-									  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+								HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+								HatchModification<BlockBehaviour.Properties> overrideProperties,
+								boolean defaultMineableTags,
+								HatchFactory factory,
+								MachineBlockRegistrators... extraRegistrators)
 	{
 		for(int i = 0; i < 2; i++)
 		{
@@ -108,30 +118,30 @@ public final class HatchMIHookContext extends MIHookContext
 		}
 	}
 	
-	@SafeVarargs
-	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									  HatchModification<BlockBehaviour.Properties> overrideProperties,
-									  HatchFactory factory,
-									  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+								HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+								HatchModification<BlockBehaviour.Properties> overrideProperties,
+								HatchFactory factory,
+								MachineBlockRegistrators... extraRegistrators)
 	{
 		registerHatches(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-									  HatchFactory factory,
-									  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+								HatchFactory factory,
+								MachineBlockRegistrators... extraRegistrators)
 	{
 		registerHatches(id, englishName, overlayFolder, casing, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-										  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-										  HatchModification<BlockBehaviour.Properties> overrideProperties,
-										  boolean defaultMineableTags,
-										  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+									HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									HatchModification<BlockBehaviour.Properties> overrideProperties,
+									boolean defaultMineableTags,
+									MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatches(id + "_item", englishName + " Item", "hatch_item", casing, modifyBlock, overrideProperties, defaultMineableTags, (bep, input, machineId) ->
 		{
@@ -157,28 +167,28 @@ public final class HatchMIHookContext extends MIHookContext
 		}, ArrayUtils.add(extraRegistrators, MachineBlockEntity::registerItemApi));
 	}
 	
-	@SafeVarargs
-	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-										  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-										  HatchModification<BlockBehaviour.Properties> overrideProperties,
-										  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+									HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									HatchModification<BlockBehaviour.Properties> overrideProperties,
+									MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerItemHatches(id, englishName, casing, rows, columns, xStart, yStart, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-										  Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+									MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerItemHatches(id, englishName, casing, rows, columns, xStart, yStart, null, null, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-										   HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-										   HatchModification<BlockBehaviour.Properties> overrideProperties,
-										   boolean defaultMineableTags,
-										   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+									 HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									 HatchModification<BlockBehaviour.Properties> overrideProperties,
+									 boolean defaultMineableTags,
+									 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatches(id + "_fluid", englishName + " Fluid", "hatch_fluid", casing, modifyBlock, overrideProperties, defaultMineableTags, (bep, input, machineId) ->
 		{
@@ -195,28 +205,28 @@ public final class HatchMIHookContext extends MIHookContext
 		}, ArrayUtils.add(extraRegistrators, MachineBlockEntity::registerFluidApi));
 	}
 	
-	@SafeVarargs
-	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-										   HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-										   HatchModification<BlockBehaviour.Properties> overrideProperties,
-										   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+									 HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									 HatchModification<BlockBehaviour.Properties> overrideProperties,
+									 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerFluidHatches(id, englishName, casing, bucketCapacity, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-										   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+									 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerFluidHatches(id, englishName, casing, bucketCapacity, null, null, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerEnergyHatches(CableTier tier,
-											HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-											HatchModification<BlockBehaviour.Properties> overrideProperties,
-											boolean defaultMineableTags,
-											Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerEnergyHatches(CableTier tier,
+									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									  HatchModification<BlockBehaviour.Properties> overrideProperties,
+									  boolean defaultMineableTags,
+									  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerHatches(
 				tier.name + "_energy", tier.shortEnglishName + " Energy",
@@ -227,18 +237,18 @@ public final class HatchMIHookContext extends MIHookContext
 		);
 	}
 	
-	@SafeVarargs
-	public final void registerEnergyHatches(CableTier tier,
-											HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-											HatchModification<BlockBehaviour.Properties> overrideProperties,
-											Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerEnergyHatches(CableTier tier,
+									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									  HatchModification<BlockBehaviour.Properties> overrideProperties,
+									  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerEnergyHatches(tier, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void registerEnergyHatches(CableTier tier,
-											Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void registerEnergyHatches(CableTier tier,
+									  MachineBlockRegistrators... extraRegistrators)
 	{
 		this.registerEnergyHatches(tier, null, null, extraRegistrators);
 	}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/HatchMIHookContext.java
@@ -15,20 +15,20 @@ import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
 import com.google.common.collect.Lists;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.HatchMachineBuilder;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
 import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 public final class HatchMIHookContext extends MIHookContext
 {
@@ -55,54 +55,64 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
+	@SafeVarargs
 	private void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-							   MachineBlockHolderModifier modifyBlock,
-							   MachineBlockPropertiesModifier overrideProperties,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
 							   boolean defaultMineableTags,
 							   HatchFactory factory,
 							   boolean input,
-							   MachineBlockRegistrators... extraRegistrators)
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
-		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, null, modifyBlock, overrideProperties, defaultMineableTags, (bep) -> factory.create(bep, input, hook.id(id)), extraRegistrators);
+		List<MachineBlockRegistrators> wrappedRegistrators = Lists.newArrayList();
+		for(var registrator : extraRegistrators)
+		{
+			wrappedRegistrators.add(registrator::accept);
+		}
+		HackedMachineRegistrationHelper.registerMachine(hook, englishName, id, null, modifyBlock != null ? modifyBlock::accept : null, overrideProperties != null ? overrideProperties::accept : null, defaultMineableTags, (bep) -> factory.create(bep, input, hook.id(id)), wrappedRegistrators.toArray(MachineBlockRegistrators[]::new));
 		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, true, false, true, false);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-							  MachineBlockHolderModifier modifyBlock,
-							  MachineBlockPropertiesModifier overrideProperties,
-							  boolean defaultMineableTags,
-							  HatchFactory factory,
-							  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+									Consumer<BlockBehaviour.Properties> overrideProperties,
+									boolean defaultMineableTags,
+									HatchFactory factory,
+									Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, defaultMineableTags, factory, false, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-							  MachineBlockHolderModifier modifyBlock,
-							  MachineBlockPropertiesModifier overrideProperties,
-							  HatchFactory factory,
-							  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+									Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+									Consumer<BlockBehaviour.Properties> overrideProperties,
+									HatchFactory factory,
+									Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
-							  HatchFactory factory,
-							  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatch(String id, String englishName, String overlayFolder, MachineCasing casing,
+									HatchFactory factory,
+									Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatch(id, englishName, overlayFolder, casing, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-								HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-								HatchModification<BlockBehaviour.Properties> overrideProperties,
-								boolean defaultMineableTags,
-								HatchFactory factory,
-								MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									  HatchModification<BlockBehaviour.Properties> overrideProperties,
+									  boolean defaultMineableTags,
+									  HatchFactory factory,
+									  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		for(int i = 0; i < 2; i++)
 		{
@@ -119,29 +129,32 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-								HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-								HatchModification<BlockBehaviour.Properties> overrideProperties,
-								HatchFactory factory,
-								MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+									  HatchModification<BlockBehaviour.Properties> overrideProperties,
+									  HatchFactory factory,
+									  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		registerHatches(id, englishName, overlayFolder, casing, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
-								HatchFactory factory,
-								MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerHatches(String id, String englishName, String overlayFolder, MachineCasing casing,
+									  HatchFactory factory,
+									  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		registerHatches(id, englishName, overlayFolder, casing, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-									HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									HatchModification<BlockBehaviour.Properties> overrideProperties,
-									boolean defaultMineableTags,
-									MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+										  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+										  HatchModification<BlockBehaviour.Properties> overrideProperties,
+										  boolean defaultMineableTags,
+										  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatches(id + "_item", englishName + " Item", "hatch_item", casing, modifyBlock, overrideProperties, defaultMineableTags, (bep, input, machineId) ->
 		{
@@ -168,27 +181,30 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-									HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									HatchModification<BlockBehaviour.Properties> overrideProperties,
-									MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+										  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+										  HatchModification<BlockBehaviour.Properties> overrideProperties,
+										  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerItemHatches(id, englishName, casing, rows, columns, xStart, yStart, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
-									MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerItemHatches(String id, String englishName, MachineCasing casing, int rows, int columns, int xStart, int yStart,
+										  Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerItemHatches(id, englishName, casing, rows, columns, xStart, yStart, null, null, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-									 HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									 HatchModification<BlockBehaviour.Properties> overrideProperties,
-									 boolean defaultMineableTags,
-									 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+										   HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+										   HatchModification<BlockBehaviour.Properties> overrideProperties,
+										   boolean defaultMineableTags,
+										   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatches(id + "_fluid", englishName + " Fluid", "hatch_fluid", casing, modifyBlock, overrideProperties, defaultMineableTags, (bep, input, machineId) ->
 		{
@@ -206,27 +222,30 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-									 HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									 HatchModification<BlockBehaviour.Properties> overrideProperties,
-									 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+										   HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+										   HatchModification<BlockBehaviour.Properties> overrideProperties,
+										   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerFluidHatches(id, englishName, casing, bucketCapacity, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
-									 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerFluidHatches(String id, String englishName, MachineCasing casing, int bucketCapacity,
+										   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerFluidHatches(id, englishName, casing, bucketCapacity, null, null, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerEnergyHatches(CableTier tier,
-									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									  HatchModification<BlockBehaviour.Properties> overrideProperties,
-									  boolean defaultMineableTags,
-									  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerEnergyHatches(CableTier tier,
+											HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+											HatchModification<BlockBehaviour.Properties> overrideProperties,
+											boolean defaultMineableTags,
+											Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerHatches(
 				tier.name + "_energy", tier.shortEnglishName + " Energy",
@@ -238,17 +257,19 @@ public final class HatchMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerEnergyHatches(CableTier tier,
-									  HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
-									  HatchModification<BlockBehaviour.Properties> overrideProperties,
-									  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerEnergyHatches(CableTier tier,
+											HatchModification<BlockWithItemHolder<?, ?>> modifyBlock,
+											HatchModification<BlockBehaviour.Properties> overrideProperties,
+											Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerEnergyHatches(tier, modifyBlock, overrideProperties, true, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void registerEnergyHatches(CableTier tier,
-									  MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void registerEnergyHatches(CableTier tier,
+											Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.registerEnergyHatches(tier, null, null, extraRegistrators);
 	}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/MultiblockMachinesMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/MultiblockMachinesMIHookContext.java
@@ -3,21 +3,28 @@ package net.swedz.tesseract.neoforge.compat.mi.hook.context.listener;
 import aztech.modern_industrialization.compat.rei.machines.MachineCategoryParams;
 import aztech.modern_industrialization.compat.rei.machines.SteamMode;
 import aztech.modern_industrialization.inventory.SlotPositions;
+import aztech.modern_industrialization.machines.BEP;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.guicomponents.ProgressBar;
 import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.recipe.MachineRecipe;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import com.google.common.collect.Lists;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.SpecialMachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
 
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 public final class MultiblockMachinesMIHookContext extends MIHookContext
@@ -33,66 +40,77 @@ public final class MultiblockMachinesMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
-		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
+		List<MachineBlockRegistrators> wrappedRegistrators = Lists.newArrayList();
+		for(var registrator : extraRegistrators)
+		{
+			wrappedRegistrators.add(registrator::accept);
+		}
+		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock != null ? modifyBlock::accept : null, overrideProperties != null ? overrideProperties::accept : null, defaultMineableTags, factory::apply, wrappedRegistrators.toArray(MachineBlockRegistrators[]::new));
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 		
@@ -100,102 +118,111 @@ public final class MultiblockMachinesMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, true, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, null, factory, extraRegistrators);
 	}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/MultiblockMachinesMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/MultiblockMachinesMIHookContext.java
@@ -3,22 +3,21 @@ package net.swedz.tesseract.neoforge.compat.mi.hook.context.listener;
 import aztech.modern_industrialization.compat.rei.machines.MachineCategoryParams;
 import aztech.modern_industrialization.compat.rei.machines.SteamMode;
 import aztech.modern_industrialization.inventory.SlotPositions;
-import aztech.modern_industrialization.machines.BEP;
-import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.guicomponents.ProgressBar;
 import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.recipe.MachineRecipe;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
-import net.swedz.tesseract.neoforge.compat.mi.machine.MachineBlockCreator;
-import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.SpecialMachineBuilder;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 public final class MultiblockMachinesMIHookContext extends MIHookContext
@@ -28,179 +27,186 @@ public final class MultiblockMachinesMIHookContext extends MIHookContext
 		super(hook);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	public SpecialMachineBuilder builder(String name, String englishName, MachineBlockEntityFactory factory)
+	{
+		return MachineBuilder.special(hook, name, englishName, true, factory);
+	}
+	
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 		
 		HackedMachineRegistrationHelper.addMachineModel(hook, name, defaultCasing, overlayFolder, frontOverlay, topOverlay, sideOverlay, hasActive);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, true, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, null, factory, extraRegistrators);
 	}
 	
+	@Deprecated(forRemoval = true)
 	public void registerRecipeCategory(String id, String englishName, MachineRecipeType recipeType, MachineCategoryParams params)
 	{
 		HackedMachineRegistrationHelper.registerRecipeCategory(hook, id, englishName, recipeType, params);
 	}
 	
+	@Deprecated(forRemoval = true)
 	public void registerRecipeCategory(String id, String englishName, MachineRecipeType recipeType,
 									   SlotPositions itemInputs, SlotPositions itemOutputs,
 									   SlotPositions fluidInputs, SlotPositions fluidOutputs,

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockCraftingMachinesMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockCraftingMachinesMIHookContext.java
@@ -10,6 +10,8 @@ import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.SingleBlockCraftingMachineBuilder;
 
 import java.util.function.Consumer;
 
@@ -20,6 +22,12 @@ public final class SingleBlockCraftingMachinesMIHookContext extends MIHookContex
 		super(hook);
 	}
 	
+	public SingleBlockCraftingMachineBuilder builder(String name, String englishName, MachineRecipeType recipeType)
+	{
+		return MachineBuilder.singleBlockCrafting(hook, name, englishName, recipeType);
+	}
+	
+	@Deprecated(forRemoval = true)
 	public void register(String englishName, String machine, MachineRecipeType type,
 						 int itemInputCount, int itemOutputCount, int fluidInputCount, int fluidOutputCount,
 						 Consumer<MachineGuiParameters.Builder> guiParams,
@@ -43,6 +51,7 @@ public final class SingleBlockCraftingMachinesMIHookContext extends MIHookContex
 		);
 	}
 	
+	@Deprecated(forRemoval = true)
 	public void register(String englishName, String machine, MachineRecipeType type,
 						 int itemInputCount, int itemOutputCount, int fluidInputCount, int fluidOutputCount,
 						 Consumer<MachineGuiParameters.Builder> guiParams,

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockSpecialMachinesMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockSpecialMachinesMIHookContext.java
@@ -1,18 +1,26 @@
 package net.swedz.tesseract.neoforge.compat.mi.hook.context.listener;
 
 import aztech.modern_industrialization.compat.rei.machines.MachineCategoryParams;
+import aztech.modern_industrialization.machines.BEP;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import com.google.common.collect.Lists;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
-import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
 import net.swedz.tesseract.neoforge.compat.mi.machine.builder.SpecialMachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public final class SingleBlockSpecialMachinesMIHookContext extends MIHookContext
 {
@@ -27,66 +35,77 @@ public final class SingleBlockSpecialMachinesMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
-		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
+		List<MachineBlockRegistrators> wrappedRegistrators = Lists.newArrayList();
+		for(var registrator : extraRegistrators)
+		{
+			wrappedRegistrators.add(registrator::accept);
+		}
+		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock != null ? modifyBlock::accept : null, overrideProperties != null ? overrideProperties::accept : null, defaultMineableTags, factory::apply, wrappedRegistrators.toArray(MachineBlockRegistrators[]::new));
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, null, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 		
@@ -94,102 +113,111 @@ public final class SingleBlockSpecialMachinesMIHookContext extends MIHookContext
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, null, null, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, true, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 boolean defaultMineableTags,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   boolean defaultMineableTags,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockFactory blockCreator,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   MachineBlockFactory blockCreator,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockHolderModifier modifyBlock,
-						 MachineBlockPropertiesModifier overrideProperties,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
+							   Consumer<BlockBehaviour.Properties> overrideProperties,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
 	@Deprecated(forRemoval = true)
-	public void register(String englishName, String name, String overlayFolder,
-						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-						 MachineBlockEntityFactory factory,
-						 MachineBlockRegistrators... extraRegistrators)
+	@SafeVarargs
+	public final void register(String englishName, String name, String overlayFolder,
+							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+							   Function<BEP, MachineBlockEntity> factory,
+							   Consumer<BlockEntityType<?>>... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, null, null, factory, extraRegistrators);
 	}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockSpecialMachinesMIHookContext.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/context/listener/SingleBlockSpecialMachinesMIHookContext.java
@@ -1,20 +1,18 @@
 package net.swedz.tesseract.neoforge.compat.mi.hook.context.listener;
 
 import aztech.modern_industrialization.compat.rei.machines.MachineCategoryParams;
-import aztech.modern_industrialization.machines.BEP;
-import aztech.modern_industrialization.machines.MachineBlockEntity;
 import aztech.modern_industrialization.machines.models.MachineCasing;
 import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
 import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.MIHookContext;
-import net.swedz.tesseract.neoforge.compat.mi.machine.MachineBlockCreator;
-import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
-
-import java.util.function.Consumer;
-import java.util.function.Function;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.MachineBuilder;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.SpecialMachineBuilder;
 
 public final class SingleBlockSpecialMachinesMIHookContext extends MIHookContext
 {
@@ -23,174 +21,180 @@ public final class SingleBlockSpecialMachinesMIHookContext extends MIHookContext
 		super(hook);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	public SpecialMachineBuilder builder(String name, String englishName, MachineBlockEntityFactory factory)
+	{
+		return MachineBuilder.special(hook, name, englishName, false, factory);
+	}
+	
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		HackedMachineRegistrationHelper.registerMachine(hook, englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, null, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 		
 		HackedMachineRegistrationHelper.addMachineModel(hook, name, defaultCasing, overlayFolder, frontOverlay, topOverlay, sideOverlay, hasActive);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay, boolean hasActive,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, hasActive, null, null, null, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, true, blockCreator, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   boolean defaultMineableTags,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 boolean defaultMineableTags,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, defaultMineableTags, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   MachineBlockCreator blockCreator,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockFactory blockCreator,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, blockCreator, modifyBlock, overrideProperties, true, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Consumer<BlockWithItemHolder<?, ?>> modifyBlock,
-							   Consumer<BlockBehaviour.Properties> overrideProperties,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockHolderModifier modifyBlock,
+						 MachineBlockPropertiesModifier overrideProperties,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, modifyBlock, overrideProperties, factory, extraRegistrators);
 	}
 	
-	@SafeVarargs
-	public final void register(String englishName, String name, String overlayFolder,
-							   MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
-							   Function<BEP, MachineBlockEntity> factory,
-							   Consumer<BlockEntityType<?>>... extraRegistrators)
+	@Deprecated(forRemoval = true)
+	public void register(String englishName, String name, String overlayFolder,
+						 MachineCasing defaultCasing, boolean frontOverlay, boolean topOverlay, boolean sideOverlay,
+						 MachineBlockEntityFactory factory,
+						 MachineBlockRegistrators... extraRegistrators)
 	{
 		this.register(englishName, name, overlayFolder, defaultCasing, frontOverlay, topOverlay, sideOverlay, null, null, null, factory, extraRegistrators);
 	}
 	
+	@Deprecated(forRemoval = true)
 	public void registerReiTiers(String englishName, String machine, MachineRecipeType recipeType, MachineCategoryParams categoryParams, int tiers)
 	{
 		HackedMachineRegistrationHelper.registerReiTiers(hook, englishName, machine, recipeType, categoryParams, tiers);

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/HatchMachineBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/HatchMachineBuilder.java
@@ -1,0 +1,238 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.inventory.ConfigurableFluidStack;
+import aztech.modern_industrialization.inventory.ConfigurableItemStack;
+import aztech.modern_industrialization.inventory.MIInventory;
+import aztech.modern_industrialization.inventory.SlotPositions;
+import aztech.modern_industrialization.machines.blockentities.hatches.EnergyHatch;
+import aztech.modern_industrialization.machines.blockentities.hatches.FluidHatch;
+import aztech.modern_industrialization.machines.blockentities.hatches.ItemHatch;
+import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
+import aztech.modern_industrialization.machines.models.MachineCasing;
+import com.google.common.collect.Lists;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHatchBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderHatchModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public final class HatchMachineBuilder extends MachineBuilder<HatchMachineBuilder>
+{
+	private RegistrationType type;
+	
+	private MachineBlockHatchBlockEntityFactory blockEntityFactory;
+	private MachineBlockHolderHatchModifier     holderHatchModifier;
+	
+	private CableTier energyCableTier;
+	
+	HatchMachineBuilder(MIHook hook,
+						String name, String englishName)
+	{
+		super(hook, name, englishName);
+	}
+	
+	public HatchMachineBuilder modify(MachineBlockHolderHatchModifier modifier)
+	{
+		this.holderHatchModifier = modifier;
+		return super.modify(null);
+	}
+	
+	public HatchMachineBuilder item(int rows, int columns, int startX, int startY)
+	{
+		Assert.that(rows > 0);
+		Assert.that(columns > 0);
+		type = RegistrationType.ITEM;
+		blockEntityFactory = (bep, input, machineId) ->
+		{
+			List<ConfigurableItemStack> itemStacks = Lists.newArrayList();
+			for(int slot = 0; slot < rows * columns; slot++)
+			{
+				if(input)
+				{
+					itemStacks.add(ConfigurableItemStack.standardInputSlot());
+				}
+				else
+				{
+					itemStacks.add(ConfigurableItemStack.standardOutputSlot());
+				}
+			}
+			var inventory = new MIInventory(
+					itemStacks,
+					Collections.emptyList(),
+					new SlotPositions.Builder().addSlots(startX, startY, columns, rows).build(),
+					SlotPositions.empty()
+			);
+			return new ItemHatch(bep, new MachineGuiParameters.Builder(machineId, true).build(), input, !name.equals("bronze"), inventory);
+		};
+		return this.registrator(ItemHatch::registerItemApi);
+	}
+	
+	public HatchMachineBuilder fluid(int bucketCapacity)
+	{
+		Assert.that(bucketCapacity > 0);
+		type = RegistrationType.FLUID;
+		blockEntityFactory = (bep, input, machineId) ->
+		{
+			List<ConfigurableFluidStack> fluidStacks = Collections.singletonList(input ?
+					ConfigurableFluidStack.standardInputSlot(bucketCapacity * 1000L) :
+					ConfigurableFluidStack.standardOutputSlot(bucketCapacity * 1000L));
+			var inventory = new MIInventory(
+					Collections.emptyList(), fluidStacks,
+					SlotPositions.empty(), new SlotPositions.Builder().addSlot(80, 40).build()
+			);
+			return new FluidHatch(bep, new MachineGuiParameters.Builder(machineId, true).build(), input, !name.equals("bronze"), inventory);
+		};
+		return this.registrator(FluidHatch::registerFluidApi);
+	}
+	
+	public HatchMachineBuilder energy(CableTier tier)
+	{
+		Assert.notNull(tier);
+		type = RegistrationType.ENERGY;
+		energyCableTier = tier;
+		blockEntityFactory = (bep, input, machineId) -> new EnergyHatch(bep, new MachineGuiParameters.Builder(machineId, false).build(), input, tier);
+		return this.registrator(EnergyHatch::registerEnergyApi);
+	}
+	
+	public HatchMachineBuilder special(MachineBlockHatchBlockEntityFactory factory)
+	{
+		Assert.notNull(factory);
+		type = RegistrationType.SPECIAL;
+		blockEntityFactory = factory;
+		return this;
+	}
+	
+	@Override
+	public HatchMachineBuilder builtinModel(MachineCasing casing, String overlayFolder, Consumer<MachineBuiltinModelBuilder> builder)
+	{
+		return super.builtinModel(casing, overlayFolder, (b) ->
+		{
+			// Hatches by default have a front and side overlay
+			b.front(true).side(true);
+			builder.accept(b);
+		});
+	}
+	
+	public HatchMachineBuilder builtinModel(MachineCasing casing, Consumer<MachineBuiltinModelBuilder> builder)
+	{
+		Assert.notNull(type, "The type must be selected before including a builtin model");
+		Assert.that(type != RegistrationType.SPECIAL, "Overlay folder must be specified for special hatches");
+		return this.builtinModel(casing, this.getDefaultOverlayFolder(), builder);
+	}
+	
+	public HatchMachineBuilder builtinModel(Consumer<MachineBuiltinModelBuilder> builder)
+	{
+		Assert.that(type == RegistrationType.ENERGY, "Machine casing must be specified for non-energy hatches");
+		return this.builtinModel(energyCableTier.casing, builder);
+	}
+	
+	private String getName()
+	{
+		return switch (type)
+		{
+			case ITEM -> name + "_item";
+			case FLUID -> name + "_fluid";
+			case ENERGY -> energyCableTier.name + "_energy";
+			case SPECIAL -> name;
+		};
+	}
+	
+	private String getEnglishName()
+	{
+		return switch (type)
+		{
+			case ITEM -> englishName + " Item";
+			case FLUID -> englishName + " Fluid";
+			case ENERGY -> energyCableTier.shortEnglishName + " Energy";
+			case SPECIAL -> englishName;
+		};
+	}
+	
+	private String getDefaultOverlayFolder()
+	{
+		return switch (type)
+		{
+			case ITEM -> "hatch_item";
+			case FLUID -> "hatch_fluid";
+			case ENERGY -> "hatch_energy";
+			default -> throw new IllegalStateException("Unexpected value: " + type);
+		};
+	}
+	
+	@Override
+	protected void internalBuild()
+	{
+		Assert.notNull(type, "Hatch type must be configured");
+		
+		var name = this.getName();
+		var englishName = this.getEnglishName();
+		
+		if(type.registersBothIO())
+		{
+			for(int i = 0; i < 2; i++)
+			{
+				boolean input = i == 0;
+				String machineId = "%s_%s_hatch".formatted(name, input ? "input" : "output");
+				String machineEnglishName = "%s %s Hatch".formatted(englishName, input ? "Input" : "Output");
+				
+				HackedMachineRegistrationHelper.registerMachine(
+						hook,
+						machineEnglishName, machineId,
+						blockFactory,
+						holderModifier != null ? holderModifier : (holderHatchModifier != null ? (holder) -> holderHatchModifier.modify(holder, input) : null),
+						propertiesModifier,
+						defaultMineableTags,
+						(bep) -> blockEntityFactory.create(bep, input, hook.id(machineId)),
+						registrators.toArray(MachineBlockRegistrators[]::new)
+				);
+				if(builtinModel != null)
+				{
+					builtinModel.build(hook, name);
+				}
+			}
+		}
+		else
+		{
+			HackedMachineRegistrationHelper.registerMachine(
+					hook,
+					englishName, name,
+					blockFactory,
+					holderModifier != null ? holderModifier : (holderHatchModifier != null ? (holder) -> holderHatchModifier.modify(holder, false) : null),
+					propertiesModifier,
+					defaultMineableTags,
+					(bep) -> blockEntityFactory.create(bep, false, hook.id(name)),
+					registrators.toArray(MachineBlockRegistrators[]::new)
+			);
+			if(builtinModel != null)
+			{
+				builtinModel.build(hook, name);
+			}
+		}
+	}
+	
+	public enum RegistrationType
+	{
+		ITEM(true),
+		FLUID(true),
+		ENERGY(true),
+		SPECIAL(false);
+		
+		private final boolean registersBothIO;
+		
+		RegistrationType(boolean registersBothIO)
+		{
+			this.registersBothIO = registersBothIO;
+		}
+		
+		public boolean registersBothIO()
+		{
+			return registersBothIO;
+		}
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineBuilder.java
@@ -1,0 +1,115 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.machines.MachineBlock;
+import aztech.modern_industrialization.machines.models.MachineCasing;
+import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import com.google.common.collect.Lists;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockHolderModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockPropertiesModifier;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class MachineBuilder<T extends MachineBuilder<T>>
+{
+	public static SingleBlockCraftingMachineBuilder singleBlockCrafting(MIHook hook,
+																		String name, String englishName,
+																		MachineRecipeType recipeType)
+	{
+		return new SingleBlockCraftingMachineBuilder(hook, name, englishName, recipeType);
+	}
+	
+	public static SpecialMachineBuilder special(MIHook hook,
+												String name, String englishName,
+												boolean isMultiblock,
+												MachineBlockEntityFactory factory)
+	{
+		return new SpecialMachineBuilder(hook, name, englishName, isMultiblock, factory);
+	}
+	
+	public static HatchMachineBuilder hatch(MIHook hook,
+											String name, String englishName)
+	{
+		return new HatchMachineBuilder(hook, name, englishName);
+	}
+	
+	protected final MIHook hook;
+	
+	protected final String name;
+	protected final String englishName;
+	
+	protected MachineBlockFactory            blockFactory = MachineBlock::new;
+	protected MachineBlockHolderModifier     holderModifier;
+	protected MachineBlockPropertiesModifier propertiesModifier;
+	
+	protected final List<MachineBlockRegistrators> registrators = Lists.newArrayList();
+	
+	protected boolean                    defaultMineableTags = true;
+	protected MachineBuiltinModelBuilder builtinModel;
+	
+	private boolean isRegistered;
+	
+	MachineBuilder(MIHook hook,
+				   String name, String englishName)
+	{
+		Assert.noneNull(hook, name, englishName);
+		this.hook = hook;
+		this.name = name;
+		this.englishName = englishName;
+	}
+	
+	public T creator(MachineBlockFactory blockFactory)
+	{
+		Assert.notNull(blockFactory);
+		this.blockFactory = blockFactory;
+		return (T) this;
+	}
+	
+	public T modify(MachineBlockHolderModifier modifier)
+	{
+		this.holderModifier = modifier;
+		return (T) this;
+	}
+	
+	public T properties(MachineBlockPropertiesModifier properties)
+	{
+		this.propertiesModifier = properties;
+		return (T) this;
+	}
+	
+	public T registrator(MachineBlockRegistrators registrator)
+	{
+		Assert.notNull(registrator);
+		registrators.add(registrator);
+		return (T) this;
+	}
+	
+	public T excludeDefaultMineableTags()
+	{
+		defaultMineableTags = false;
+		return (T) this;
+	}
+	
+	public T builtinModel(MachineCasing casing, String overlayFolder, Consumer<MachineBuiltinModelBuilder> builder)
+	{
+		Assert.that(builtinModel == null, "Simple model has already been registered for this machine");
+		Assert.noneNull(overlayFolder, builder);
+		builtinModel = new MachineBuiltinModelBuilder(casing, overlayFolder);
+		builder.accept(builtinModel);
+		return (T) this;
+	}
+	
+	protected abstract void internalBuild();
+	
+	public final void build()
+	{
+		Assert.that(!isRegistered, "This machine is already registered");
+		isRegistered = true;
+		this.internalBuild();
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineBuiltinModelBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineBuiltinModelBuilder.java
@@ -1,0 +1,55 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.machines.models.MachineCasing;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+
+public class MachineBuiltinModelBuilder
+{
+	private final MachineCasing casing;
+	private final String        overlayFolder;
+	
+	private boolean front, top, side, active;
+	
+	MachineBuiltinModelBuilder(MachineCasing casing, String overlayFolder)
+	{
+		Assert.noneNull(casing, overlayFolder);
+		this.casing = casing;
+		this.overlayFolder = overlayFolder;
+	}
+	
+	public MachineBuiltinModelBuilder front(boolean front)
+	{
+		this.front = front;
+		return this;
+	}
+	
+	public MachineBuiltinModelBuilder top(boolean top)
+	{
+		this.top = top;
+		return this;
+	}
+	
+	public MachineBuiltinModelBuilder side(boolean side)
+	{
+		this.side = side;
+		return this;
+	}
+	
+	public MachineBuiltinModelBuilder active(boolean active)
+	{
+		this.active = active;
+		return this;
+	}
+	
+	void build(MIHook hook, String id, MachineCasing casing)
+	{
+		HackedMachineRegistrationHelper.addMachineModel(hook, id, casing, overlayFolder, front, top, side, active);
+	}
+	
+	void build(MIHook hook, String id)
+	{
+		this.build(hook, id, casing);
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineRecipeCategoryBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/MachineRecipeCategoryBuilder.java
@@ -1,0 +1,166 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.compat.rei.machines.MachineCategoryParams;
+import aztech.modern_industrialization.compat.rei.machines.SteamMode;
+import aztech.modern_industrialization.inventory.SlotPositions;
+import aztech.modern_industrialization.machines.components.MachineInventoryComponent;
+import aztech.modern_industrialization.machines.guicomponents.ProgressBar;
+import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
+import net.swedz.tesseract.neoforge.compat.mi.helper.MachineInventoryHelper;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineRecipePredicate;
+
+import java.util.function.Consumer;
+
+public final class MachineRecipeCategoryBuilder
+{
+	private final boolean           isMultiblock;
+	private final SteamMode         steamMode;
+	private final MachineRecipeType recipeType;
+	
+	private SlotPositions itemInputPositions  = new SlotPositions.Builder().build();
+	private SlotPositions itemOutputPositions = new SlotPositions.Builder().build();
+	
+	private SlotPositions fluidInputPositions  = new SlotPositions.Builder().build();
+	private SlotPositions fluidOutputPositions = new SlotPositions.Builder().build();
+	
+	ProgressBar.Parameters progressBar;
+	
+	private MachineRecipePredicate predicate = (recipe) -> true;
+	
+	MachineRecipeCategoryBuilder(boolean isMultiblock, SteamMode steamMode, MachineRecipeType recipeType)
+	{
+		this.isMultiblock = isMultiblock;
+		this.steamMode = steamMode;
+		this.recipeType = recipeType;
+	}
+	
+	public MachineRecipeCategoryBuilder items(Consumer<SlotPositions.Builder> input,
+											  Consumer<SlotPositions.Builder> output)
+	{
+		this.itemInputPositions = new SlotPositions.Builder().buildWithConsumer(input);
+		this.itemOutputPositions = new SlotPositions.Builder().buildWithConsumer(output);
+		return this;
+	}
+	
+	public MachineRecipeCategoryBuilder fluids(Consumer<SlotPositions.Builder> input,
+											   Consumer<SlotPositions.Builder> output)
+	{
+		this.fluidInputPositions = new SlotPositions.Builder().buildWithConsumer(input);
+		this.fluidOutputPositions = new SlotPositions.Builder().buildWithConsumer(output);
+		return this;
+	}
+	
+	public MachineRecipeCategoryBuilder progressBar(int renderX, int renderY, String progressBarType, boolean isVertical)
+	{
+		progressBar = new ProgressBar.Parameters(renderX, renderY, progressBarType, isVertical);
+		return this;
+	}
+	
+	public MachineRecipeCategoryBuilder progressBar(int renderX, int renderY, String progressBarType)
+	{
+		return this.progressBar(renderX, renderY, progressBarType, false);
+	}
+	
+	public MachineRecipeCategoryBuilder predicate(MachineRecipePredicate predicate)
+	{
+		Assert.notNull(predicate);
+		this.predicate = predicate;
+		return this;
+	}
+	
+	private static SlotPositions combine(SlotPositions a, SlotPositions b)
+	{
+		var combined = new SlotPositions.Builder();
+		for(int i = 0; i < a.size(); i++)
+		{
+			combined.addSlot(a.getX(i), a.getY(i));
+		}
+		for(int i = 0; i < b.size(); i++)
+		{
+			combined.addSlot(b.getX(i), b.getY(i));
+		}
+		return combined.build();
+	}
+	
+	private SlotPositions itemPositions()
+	{
+		return combine(itemInputPositions, itemOutputPositions);
+	}
+	
+	private SlotPositions fluidPositions()
+	{
+		return combine(fluidInputPositions, fluidOutputPositions);
+	}
+	
+	boolean hasInputs()
+	{
+		return itemInputPositions.size() > 0 || fluidInputPositions.size() > 0;
+	}
+	
+	boolean hasOutputs()
+	{
+		return itemOutputPositions.size() > 0 || fluidOutputPositions.size() > 0;
+	}
+	
+	boolean hasItems()
+	{
+		return itemInputPositions.size() > 0 || itemOutputPositions.size() > 0;
+	}
+	
+	boolean hasFluids()
+	{
+		return fluidInputPositions.size() > 0 || fluidOutputPositions.size() > 0;
+	}
+	
+	MachineInventoryComponent buildInventory(int steamBuckets, int bucketCapacity)
+	{
+		return MachineInventoryHelper.buildInventoryComponent(
+				itemInputPositions.size(), itemOutputPositions.size(),
+				fluidInputPositions.size(), fluidOutputPositions.size(),
+				this.itemPositions(), this.fluidPositions(),
+				steamBuckets, bucketCapacity
+		);
+	}
+	
+	void build(MIHook hook,
+			   String name, String englishName,
+			   int tiers)
+	{
+		Assert.notNull(progressBar, "Progress bar must be configured");
+		Assert.that(this.hasInputs() && this.hasOutputs(), "At least one input and one output slot must be provided");
+		
+		HackedMachineRegistrationHelper.registerReiTiers(
+				hook,
+				englishName, name, recipeType,
+				// The null and false constants are populated by registerReiTiers
+				new MachineCategoryParams(
+						null, null,
+						itemInputPositions, itemOutputPositions,
+						fluidInputPositions, fluidOutputPositions,
+						progressBar,
+						null, null, false, null
+				),
+				tiers
+		);
+	}
+	
+	void build(MIHook hook,
+			   String name, String englishName)
+	{
+		Assert.notNull(progressBar, "Progress bar must be configured");
+		Assert.that(this.hasInputs() && this.hasOutputs(), "At least one input and one output slot must be provided");
+		
+		HackedMachineRegistrationHelper.registerRecipeCategory(
+				hook,
+				name, englishName, recipeType,
+				itemInputPositions, itemOutputPositions,
+				fluidInputPositions, fluidOutputPositions,
+				progressBar,
+				(recipe) -> predicate.test(recipe),
+				isMultiblock, steamMode
+		);
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SingleBlockCraftingMachineBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SingleBlockCraftingMachineBuilder.java
@@ -1,0 +1,231 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.api.energy.CableTier;
+import aztech.modern_industrialization.compat.rei.machines.SteamMode;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
+import aztech.modern_industrialization.machines.blockentities.ElectricCraftingMachineBlockEntity;
+import aztech.modern_industrialization.machines.blockentities.SteamCraftingMachineBlockEntity;
+import aztech.modern_industrialization.machines.gui.MachineGuiParameters;
+import aztech.modern_industrialization.machines.guicomponents.EnergyBar;
+import aztech.modern_industrialization.machines.guicomponents.RecipeEfficiencyBar;
+import aztech.modern_industrialization.machines.init.MachineTier;
+import aztech.modern_industrialization.machines.models.MachineCasing;
+import aztech.modern_industrialization.machines.models.MachineCasings;
+import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import net.minecraft.resources.ResourceLocation;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static aztech.modern_industrialization.machines.init.SingleBlockCraftingMachines.*;
+
+public final class SingleBlockCraftingMachineBuilder extends MachineBuilder<SingleBlockCraftingMachineBuilder>
+{
+	private final MachineRecipeType recipeType;
+	
+	private int tiers;
+	
+	private Function<ResourceLocation, MachineGuiParameters> guiParameters = (id) -> new MachineGuiParameters.Builder(id, true).build();
+	
+	private MachineRecipeCategoryBuilder recipeCategory;
+	private int                          bucketCapacity;
+	
+	private RecipeEfficiencyBar.Parameters efficiencyBar;
+	private EnergyBar.Parameters           energyBar;
+	
+	private Config extraConfig = new Config();
+	
+	SingleBlockCraftingMachineBuilder(MIHook hook,
+									  String name, String englishName,
+									  MachineRecipeType recipeType)
+	{
+		super(hook, name, englishName);
+		Assert.notNull(recipeType);
+		this.recipeType = recipeType;
+	}
+	
+	@Override
+	public SingleBlockCraftingMachineBuilder builtinModel(MachineCasing casing, String overlayFolder, Consumer<MachineBuiltinModelBuilder> builder)
+	{
+		return super.builtinModel(casing, overlayFolder, (b) ->
+		{
+			// All crafting machines should use active overlays
+			b.active(true);
+			builder.accept(b);
+		});
+	}
+	
+	public SingleBlockCraftingMachineBuilder bronze()
+	{
+		tiers |= TIER_BRONZE;
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder steel()
+	{
+		tiers |= TIER_STEEL;
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder electric()
+	{
+		tiers |= TIER_ELECTRIC;
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder gui(boolean lockButton, int backgroundHeight)
+	{
+		guiParameters = (id) -> new MachineGuiParameters.Builder(id, lockButton).backgroundHeight(backgroundHeight).build();
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder gui(int backgroundHeight)
+	{
+		return this.gui(true, backgroundHeight);
+	}
+	
+	public SingleBlockCraftingMachineBuilder recipeCategory(SteamMode steamMode, Consumer<MachineRecipeCategoryBuilder> builder)
+	{
+		Assert.noneNull(steamMode, builder);
+		recipeCategory = new MachineRecipeCategoryBuilder(false, steamMode, recipeType);
+		builder.accept(recipeCategory);
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder fluids(int bucketCapacity)
+	{
+		this.bucketCapacity = bucketCapacity;
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder efficiencyBar(int renderX, int renderY)
+	{
+		efficiencyBar = new RecipeEfficiencyBar.Parameters(renderX, renderY);
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder energyBar(int renderX, int renderY)
+	{
+		energyBar = new EnergyBar.Parameters(renderX, renderY);
+		return this;
+	}
+	
+	public SingleBlockCraftingMachineBuilder extra(Consumer<Config> builder)
+	{
+		builder.accept(extraConfig);
+		return this;
+	}
+	
+	private static MachineCasing getCasing(MachineTier tier)
+	{
+		return switch (tier)
+		{
+			case BRONZE -> MachineCasings.BRONZE;
+			case STEEL -> MachineCasings.STEEL;
+			case LV -> CableTier.LV.casing;
+			default -> throw new RuntimeException("Invalid tier: " + tier);
+		};
+	}
+	
+	@Override
+	protected void internalBuild()
+	{
+		Assert.that(tiers != 0, "At least one tier must be selected");
+		Assert.notNull(recipeCategory, "Recipe category must be configured");
+		
+		// Register the bronze and steel machines
+		for(int index = 0; index < 2; ++index)
+		{
+			if(index == 0 && (tiers & TIER_BRONZE) == 0)
+			{
+				continue;
+			}
+			if(index == 1 && (tiers & TIER_STEEL) == 0)
+			{
+				continue;
+			}
+			
+			MachineTier tier = index == 0 ? MachineTier.BRONZE : MachineTier.STEEL;
+			String prefix = index == 0 ? "bronze" : "steel";
+			String englishPrefix = index == 0 ? "Bronze " : "Steel ";
+			int steamBuckets = index == 0 ? 2 : 4;
+			String id = prefix + "_" + name;
+			var guiParams = guiParameters.apply(hook.id(id));
+			
+			HackedMachineRegistrationHelper.registerMachine(
+					hook,
+					englishPrefix + englishName, id,
+					blockFactory, holderModifier, propertiesModifier,
+					defaultMineableTags,
+					(bet) -> new SteamCraftingMachineBlockEntity(
+							bet, recipeType,
+							recipeCategory.buildInventory(steamBuckets, bucketCapacity),
+							guiParams, recipeCategory.progressBar, tier, extraConfig.steamOverclockCatalysts
+					),
+					(bet) ->
+					{
+						if(recipeCategory.hasItems())
+						{
+							MachineBlockEntity.registerItemApi(bet);
+						}
+						MachineBlockEntity.registerFluidApi(bet);
+					}
+			);
+			if(builtinModel != null)
+			{
+				builtinModel.build(hook, id, getCasing(tier));
+			}
+		}
+		
+		// Register the electric machine
+		if((tiers & TIER_ELECTRIC) > 0)
+		{
+			Assert.notNull(efficiencyBar, "Progress bar must be configured");
+			Assert.notNull(energyBar, "Energy bar must be configured");
+			
+			String id = tiers == TIER_ELECTRIC ? name : "electric_" + name;
+			
+			var guiParams = guiParameters.apply(hook.id(id));
+			
+			String electricEnglishName = englishName;
+			
+			if((tiers & TIER_BRONZE) > 0 | (tiers & TIER_STEEL) > 0)
+			{
+				electricEnglishName = "Electric " + englishName;
+			}
+			
+			HackedMachineRegistrationHelper.registerMachine(
+					hook,
+					electricEnglishName, id,
+					blockFactory, holderModifier, propertiesModifier,
+					defaultMineableTags,
+					(bet) -> new ElectricCraftingMachineBlockEntity(
+							bet, recipeType,
+							recipeCategory.buildInventory(0, bucketCapacity),
+							guiParams, energyBar, recipeCategory.progressBar, efficiencyBar, MachineTier.LV, 3200
+					),
+					(bet) ->
+					{
+						ElectricCraftingMachineBlockEntity.registerEnergyApi(bet);
+						if(recipeCategory.hasItems())
+						{
+							MachineBlockEntity.registerItemApi(bet);
+						}
+						if(recipeCategory.hasFluids())
+						{
+							MachineBlockEntity.registerFluidApi(bet);
+						}
+					}
+			);
+			if(builtinModel != null)
+			{
+				builtinModel.build(hook, id, getCasing(MachineTier.LV));
+			}
+		}
+		
+		recipeCategory.build(hook, name, englishName, tiers);
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SpecialMachineBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SpecialMachineBuilder.java
@@ -1,0 +1,61 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder;
+
+import aztech.modern_industrialization.compat.rei.machines.SteamMode;
+import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
+import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.compat.mi.hack.HackedMachineRegistrationHelper;
+import net.swedz.tesseract.neoforge.compat.mi.hook.MIHook;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockEntityFactory;
+import net.swedz.tesseract.neoforge.compat.mi.machine.builder.function.MachineBlockRegistrators;
+
+import java.util.function.Consumer;
+
+public final class SpecialMachineBuilder extends MachineBuilder<SpecialMachineBuilder>
+{
+	private final boolean isMultiblock;
+	
+	private final MachineBlockEntityFactory blockEntityFactory;
+	
+	private MachineRecipeCategoryBuilder recipeCategory;
+	
+	SpecialMachineBuilder(MIHook hook,
+						  String name, String englishName,
+						  boolean isMultiblock,
+						  MachineBlockEntityFactory blockEntityFactory)
+	{
+		super(hook, name, englishName);
+		Assert.notNull(blockEntityFactory);
+		this.isMultiblock = isMultiblock;
+		this.blockEntityFactory = blockEntityFactory;
+	}
+	
+	public SpecialMachineBuilder recipeCategory(SteamMode steamMode, MachineRecipeType recipeType,
+												Consumer<MachineRecipeCategoryBuilder> builder)
+	{
+		Assert.noneNull(steamMode, recipeType, builder);
+		recipeCategory = new MachineRecipeCategoryBuilder(isMultiblock, steamMode, recipeType);
+		builder.accept(recipeCategory);
+		return this;
+	}
+	
+	@Override
+	protected void internalBuild()
+	{
+		HackedMachineRegistrationHelper.registerMachine(
+				hook,
+				englishName, name,
+				blockFactory, holderModifier, propertiesModifier,
+				defaultMineableTags,
+				blockEntityFactory,
+				registrators.toArray(MachineBlockRegistrators[]::new)
+		);
+		if(builtinModel != null)
+		{
+			builtinModel.build(hook, name);
+		}
+		if(recipeCategory != null)
+		{
+			recipeCategory.build(hook, name, englishName);
+		}
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockEntityFactory.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockEntityFactory.java
@@ -1,0 +1,16 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import aztech.modern_industrialization.machines.BEP;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
+
+@FunctionalInterface
+public interface MachineBlockEntityFactory
+{
+	/**
+	 * Creates the {@link MachineBlockEntity} for the machine.
+	 *
+	 * @param bep the block entity parameters
+	 * @return the {@link MachineBlockEntity}
+	 */
+	MachineBlockEntity create(BEP bep);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockFactory.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockFactory.java
@@ -1,4 +1,4 @@
-package net.swedz.tesseract.neoforge.compat.mi.machine;
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
 
 import aztech.modern_industrialization.machines.MachineBlock;
 import aztech.modern_industrialization.machines.MachineBlockEntity;
@@ -9,7 +9,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import java.util.function.BiFunction;
 
 @FunctionalInterface
-public interface MachineBlockCreator
+public interface MachineBlockFactory
 {
 	/**
 	 * Creates a machine block.

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHatchBlockEntityFactory.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHatchBlockEntityFactory.java
@@ -1,0 +1,19 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import aztech.modern_industrialization.machines.BEP;
+import aztech.modern_industrialization.machines.multiblocks.HatchBlockEntity;
+import net.minecraft.resources.ResourceLocation;
+
+@FunctionalInterface
+public interface MachineBlockHatchBlockEntityFactory
+{
+	/**
+	 * Creates the {@link HatchBlockEntity} for the machine.
+	 *
+	 * @param bep       the block entity parameters
+	 * @param input     true if this hatch is an input hatch, false otherwise
+	 * @param machineId the full id of the machine
+	 * @return the {@link HatchBlockEntity}
+	 */
+	HatchBlockEntity create(BEP bep, boolean input, ResourceLocation machineId);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHolderHatchModifier.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHolderHatchModifier.java
@@ -1,0 +1,15 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
+
+@FunctionalInterface
+public interface MachineBlockHolderHatchModifier
+{
+	/**
+	 * Modifies the holder for the machine block.
+	 *
+	 * @param holder the {@link BlockWithItemHolder} that will be registered
+	 * @param input  true if this hatch is an input hatch, false otherwise
+	 */
+	void modify(BlockWithItemHolder<?, ?> holder, boolean input);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHolderModifier.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockHolderModifier.java
@@ -1,0 +1,14 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import net.swedz.tesseract.neoforge.registry.holder.BlockWithItemHolder;
+
+@FunctionalInterface
+public interface MachineBlockHolderModifier
+{
+	/**
+	 * Modifies the holder for the machine block.
+	 *
+	 * @param holder the {@link BlockWithItemHolder} that will be registered
+	 */
+	void modify(BlockWithItemHolder<?, ?> holder);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockPropertiesModifier.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockPropertiesModifier.java
@@ -1,0 +1,14 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import net.minecraft.world.level.block.state.BlockBehaviour;
+
+@FunctionalInterface
+public interface MachineBlockPropertiesModifier
+{
+	/**
+	 * Modifies the block properties for the machine block.
+	 *
+	 * @param properties the {@link BlockBehaviour.Properties} of the block
+	 */
+	void modify(BlockBehaviour.Properties properties);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockRegistrators.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineBlockRegistrators.java
@@ -1,0 +1,14 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+@FunctionalInterface
+public interface MachineBlockRegistrators
+{
+	/**
+	 * Applies some extra registration on the machine block entity.
+	 *
+	 * @param blockEntityType the block entity type
+	 */
+	void apply(BlockEntityType<?> blockEntityType);
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineRecipePredicate.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/function/MachineRecipePredicate.java
@@ -1,0 +1,15 @@
+package net.swedz.tesseract.neoforge.compat.mi.machine.builder.function;
+
+import aztech.modern_industrialization.machines.recipe.MachineRecipe;
+
+@FunctionalInterface
+public interface MachineRecipePredicate
+{
+	/**
+	 * Check if the recipe should be applicable to the recipe category.
+	 *
+	 * @param recipe the {@link MachineRecipe}
+	 * @return true if the recipe should be applicable, false otherwise
+	 */
+	boolean test(MachineRecipe recipe);
+}


### PR DESCRIPTION
Closes #70 

This deprecates all the old methods inside of the hook contexts in favor of this new builder system.

I intend on removing the deprecated methods in the next major version release for Tesseract API (1.9.x+). Doing a slow rollout for this because its kind of a massive change. Please use this time to get familiar with and test the new system before I drop the old methods.