### PR TITLE
Allow for config keys be generated based on the method name

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/config/ConfigHandler.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/config/ConfigHandler.java
@@ -5,6 +5,7 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 import net.swedz.tesseract.neoforge.Tesseract;
 import net.swedz.tesseract.neoforge.config.annotation.ConfigKey;
 import net.swedz.tesseract.neoforge.config.annotation.SubSection;
+import net.swedz.tesseract.neoforge.helper.NamingConventionHelper;
 import net.swedz.tesseract.neoforge.serialization.TomlOps;
 
 import java.lang.reflect.InvocationHandler;
@@ -72,6 +73,10 @@ public final class ConfigHandler implements InvocationHandler
 			if(method.isAnnotationPresent(ConfigKey.class))
 			{
 				String key = method.getAnnotation(ConfigKey.class).value();
+				if(key.isEmpty())
+				{
+					key = NamingConventionHelper.fromCamelCaseToSnakeCase(method);
+				}
 				String path = this.path(key);
 				var type = method.getReturnType();
 				

--- a/src/main/java/net/swedz/tesseract/neoforge/config/ConfigManager.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/config/ConfigManager.java
@@ -9,6 +9,7 @@ import net.swedz.tesseract.neoforge.config.annotation.ConfigKey;
 import net.swedz.tesseract.neoforge.config.annotation.ConfigOrder;
 import net.swedz.tesseract.neoforge.config.annotation.Range;
 import net.swedz.tesseract.neoforge.config.annotation.SubSection;
+import net.swedz.tesseract.neoforge.helper.NamingConventionHelper;
 import net.swedz.tesseract.neoforge.serialization.TomlOps;
 
 import java.lang.reflect.InvocationHandler;
@@ -100,6 +101,10 @@ public final class ConfigManager
 				}
 				
 				String key = method.getAnnotation(ConfigKey.class).value();
+				if(key.isEmpty())
+				{
+					key = NamingConventionHelper.fromCamelCaseToSnakeCase(method);
+				}
 				Class type = method.getReturnType();
 				
 				if(!keys.add(key))

--- a/src/main/java/net/swedz/tesseract/neoforge/config/annotation/ConfigKey.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/config/annotation/ConfigKey.java
@@ -9,5 +9,13 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface ConfigKey
 {
-	String value();
+	/**
+	 * <p>The key to use for the config entry.</p>
+	 *
+	 * <p>If left unspecified (or empty), the key will be generated using the method name. The method name is assumed
+	 * to be in camelCase. The key used for the config will be the method name converted to snake_case.</p>
+	 *
+	 * @return the config key to use
+	 */
+	String value() default "";
 }

--- a/src/main/java/net/swedz/tesseract/neoforge/helper/NamingConventionHelper.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/helper/NamingConventionHelper.java
@@ -1,0 +1,56 @@
+package net.swedz.tesseract.neoforge.helper;
+
+import java.lang.reflect.Method;
+import java.util.regex.Pattern;
+
+public final class NamingConventionHelper
+{
+	private static final Pattern CAMEL_CASE_PATTERN = Pattern.compile("([A-Z][a-z]+)|([a-z]+)|([0-9]+)|([A-Z]+(?![a-z]))");
+	
+	/**
+	 * <p>Converts a method's name from camelCase to snake_case.</p>
+	 *
+	 * <p>Each "word" is converted to lowercase and joined with an underscore for the delimiter. As such, the method
+	 * name is matched against the regex pattern <code>([A-Z][a-z]+)|([a-z]+)|([0-9]+)|([A-Z]+(?![a-z]))</code>.</p>
+	 *
+	 * @param methodName the method's name, in camelCase
+	 * @return the method's name converted to snake_case
+	 */
+	public static String fromCamelCaseToSnakeCase(String methodName)
+	{
+		var generated = new StringBuilder();
+		var matcher = CAMEL_CASE_PATTERN.matcher(methodName);
+		int lastEnd = 0;
+		while(matcher.find())
+		{
+			int start = matcher.start();
+			int end = matcher.end();
+			// Append any non-matched characters
+			if(lastEnd < start)
+			{
+				generated.append(methodName, lastEnd, start);
+			}
+			if(!generated.isEmpty())
+			{
+				generated.append('_');
+			}
+			generated.append(methodName, start, end);
+			lastEnd = end;
+		}
+		return generated.toString().toLowerCase();
+	}
+	
+	/**
+	 * <p>Converts a method's name from camelCase to snake_case.</p>
+	 *
+	 * <p>Each "word" is converted to lowercase and joined with an underscore for the delimiter. As such, the method
+	 * name is matched against the regex pattern <code>([A-Z][a-z]+)|([a-z]+)|([0-9]+)|([A-Z]+(?![a-z]))</code>.</p>
+	 *
+	 * @param method the method, whose name is in camelCase
+	 * @return the method's name converted to snake_case
+	 */
+	public static String fromCamelCaseToSnakeCase(Method method)
+	{
+		return fromCamelCaseToSnakeCase(method.getName());
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/lang/LangHandler.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/lang/LangHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.swedz.tesseract.neoforge.api.Assert;
+import net.swedz.tesseract.neoforge.helper.NamingConventionHelper;
 import net.swedz.tesseract.neoforge.lang.annotation.LangKey;
 import net.swedz.tesseract.neoforge.lang.annotation.LangKeyPattern;
 import net.swedz.tesseract.neoforge.lang.annotation.Parsed;
@@ -19,12 +20,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 public final class LangHandler implements InvocationHandler
 {
-	private static final Pattern METHOD_PATTERN = Pattern.compile("([A-Z][a-z]+)|([a-z]+)|([0-9]+)|([A-Z]+(?![a-z]))");
-	
 	private final LangManager manager;
 	
 	private Map<String, LangEntry> values = Map.of();
@@ -39,30 +37,6 @@ public final class LangHandler implements InvocationHandler
 		return values.values().stream()
 				.sorted(Comparator.comparing(LangEntry::key))
 				.toList();
-	}
-	
-	private static String generateLangKey(String methodName)
-	{
-		var generated = new StringBuilder();
-		var matcher = METHOD_PATTERN.matcher(methodName);
-		int lastEnd = 0;
-		while(matcher.find())
-		{
-			int start = matcher.start();
-			int end = matcher.end();
-			// Append any non-matched characters
-			if(lastEnd < start)
-			{
-				generated.append(methodName, lastEnd, start);
-			}
-			if(!generated.isEmpty())
-			{
-				generated.append('_');
-			}
-			generated.append(methodName, start, end);
-			lastEnd = end;
-		}
-		return generated.toString().toLowerCase();
 	}
 	
 	private String createLangKey(Class<?> langClass, Method method)
@@ -82,7 +56,7 @@ public final class LangHandler implements InvocationHandler
 		
 		var key = !annotation.key().isEmpty() ?
 				annotation.key() :
-				generateLangKey(method.getName());
+				NamingConventionHelper.fromCamelCaseToSnakeCase(method);
 		return prefix + key;
 	}
 	


### PR DESCRIPTION
Same functionality for how language keys can be generated based on method names.

Simply do not provide a value in the `@ConfigKey` annotation to use a generated key.