### PR TITLE
Support custom MI machines not being able to be upgraded using the Steel Upgrade

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/mixin/FixSteelUpgradeItemMixin.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/mixin/FixSteelUpgradeItemMixin.java
@@ -1,0 +1,34 @@
+package net.swedz.tesseract.neoforge.compat.mi.mixin;
+
+import aztech.modern_industrialization.items.SteelUpgradeItem;
+import aztech.modern_industrialization.machines.init.MachineTier;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.swedz.tesseract.neoforge.compat.mi.api.MachineTierHolder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(SteelUpgradeItem.class)
+public class FixSteelUpgradeItemMixin
+{
+	@Definition(
+			id = "canUpgrade",
+			local = @Local(type = boolean.class)
+	)
+	@Expression("canUpgrade")
+	@ModifyExpressionValue(
+			method = "useOn",
+			at = @At("MIXINEXTRAS:EXPRESSION")
+	)
+	private boolean canUpgrade(
+			boolean original,
+			@Local(name = "be") BlockEntity blockEntity
+	)
+	{
+		return original ||
+			   (blockEntity instanceof MachineTierHolder tierHolder && tierHolder.getMachineTier() == MachineTier.BRONZE);
+	}
+}

--- a/src/main/resources/tesseract_api_mi.mixins.json
+++ b/src/main/resources/tesseract_api_mi.mixins.json
@@ -1,11 +1,15 @@
 {
     "required": true,
     "minVersion": "0.8",
+    "mixinextras": {
+        "minVersion": "0.5.0"
+    },
     "package": "net.swedz.tesseract.neoforge.compat.mi.mixin",
     "plugin": "net.swedz.tesseract.neoforge.compat.mi.MIMixinPlugin",
     "compatibilityLevel": "JAVA_21",
     "mixins": [
         "ActiveRecipeHolderMixin",
+        "FixSteelUpgradeItemMixin",
         "accessor.CasingComponentAccessor",
         "accessor.ConfigurableStackAccessor",
         "accessor.CrafterComponentAccessor",


### PR DESCRIPTION
So long as the machine implements `MachineTierHolder` (or by extension, `SteamMachineTierHolder`) and it is a bronze tier machine, then the steel upgrade item can be used on the machine.