### PR TITLE
Execute enqueued MI hook tasks in the correct order

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hack/HackedMachineRegistrationHelper.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hack/HackedMachineRegistrationHelper.java
@@ -586,12 +586,13 @@ public final class HackedMachineRegistrationHelper
 			Function<ResourceLocation, MachineRecipeType> creator
 	)
 	{
-		MIHookRegistry registry = hook.registry();
+		var registry = hook.registry();
 		
-		MachineRecipeType type = creator.apply(hook.id(name));
+		var type = creator.apply(hook.id(name));
 		registry.recipeSerializerRegistry().register(name, () -> type);
 		registry.recipeTypeRegistry().register(name, () -> type);
 		registry.onMachineRecipeTypeRegister(type);
+		MIHookTracker.addRecipeType(type);
 		hook.enqueue(() -> MIMachineRecipeTypesAccessor.getRecipeTypes().add(type));
 		
 		return type;

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHook.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHook.java
@@ -2,6 +2,7 @@ package net.swedz.tesseract.neoforge.compat.mi.hook;
 
 import com.google.common.collect.Lists;
 import net.minecraft.resources.ResourceLocation;
+import net.swedz.tesseract.neoforge.Tesseract;
 
 import java.util.List;
 import java.util.Objects;
@@ -102,7 +103,15 @@ public final class MIHook
 	void executeEnqueuedTasks()
 	{
 		executedEnqueuedTasks = true;
-		tasks.forEach(Runnable::run);
+		Tesseract.LOGGER.info("Executing enqueued MI hook tasks for {}", modId);
+		try
+		{
+			tasks.forEach(Runnable::run);
+		}
+		catch(Exception ex)
+		{
+			throw new RuntimeException("Failed to execute enqueued MI hook tasks for " + modId, ex);
+		}
 		tasks.clear();
 	}
 }

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHookTracker.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHookTracker.java
@@ -1,7 +1,9 @@
 package net.swedz.tesseract.neoforge.compat.mi.hook;
 
 import aztech.modern_industrialization.MI;
+import aztech.modern_industrialization.machines.init.MIMachineRecipeTypes;
 import aztech.modern_industrialization.machines.models.MachineCasing;
+import aztech.modern_industrialization.machines.recipe.MachineRecipeType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
@@ -19,6 +21,7 @@ public final class MIHookTracker
 	private static final Map<ResourceLocation, String>                                         REI_CATEGORY_NAMES    = Maps.newConcurrentMap();
 	private static final Map<ResourceLocation, MachineModelProperties>                         MACHINE_MODELS        = Maps.newConcurrentMap();
 	private static final Map<String, List<Consumer<MachineCasingModelsMIHookDatagenProvider>>> MACHINE_CASING_MODELS = Maps.newConcurrentMap();
+	private static final Map<ResourceLocation, MachineRecipeType>                              RECIPE_TYPES          = Maps.newConcurrentMap();
 	
 	public static List<Map.Entry<ResourceLocation, String>> getReiCategoryNames(String modId)
 	{
@@ -105,5 +108,23 @@ public final class MIHookTracker
 			
 			json.add("default_overlays", defaultOverlays);
 		}
+	}
+	
+	public static void addRecipeType(MachineRecipeType type)
+	{
+		RECIPE_TYPES.put(type.getId(), type);
+	}
+	
+	public static MachineRecipeType getRecipeType(ResourceLocation key)
+	{
+		var type = RECIPE_TYPES.get(key);
+		if(type == null)
+		{
+			type = MIMachineRecipeTypes.getRecipeTypes().stream()
+					.filter((miType) -> miType.getId().equals(key))
+					.findFirst()
+					.orElse(null);
+		}
+		return type;
 	}
 }

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHooks.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/hook/MIHooks.java
@@ -1,10 +1,12 @@
 package net.swedz.tesseract.neoforge.compat.mi.hook;
 
 import com.google.common.collect.Maps;
+import net.neoforged.fml.ModList;
 import net.swedz.tesseract.neoforge.compat.mi.hook.context.machine.EfficiencyMIHookContext;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -16,6 +18,22 @@ public final class MIHooks
 {
 	private static final Map<String, MIHook>   HOOKS                = Maps.newHashMap();
 	private static final Set<MIHookEfficiency> EFFICIENCY_LISTENERS = new TreeSet<>(Comparator.comparingInt(MIHookEfficiency::getPriority));
+	
+	private static List<MIHook> sortedHooks()
+	{
+		var modList = ModList.get();
+		return HOOKS.values().stream()
+				.sorted(Comparator.comparingInt((hook) ->
+				{
+					var container = modList.getModContainerById(hook.modId());
+					if(container.isEmpty())
+					{
+						throw new IllegalStateException("Mod container for " + hook.modId() + " does not exist!");
+					}
+					return modList.getSortedMods().indexOf(container.get());
+				}))
+				.toList();
+	}
 	
 	static void registerListener(String modId, MIHookListener listener)
 	{
@@ -117,9 +135,9 @@ public final class MIHooks
 	public static void executeEnqueuedTasks()
 	{
 		MIHookEntrypointLoader.ensureLoaded();
-		for(var entry : HOOKS.entrySet())
+		for(var hook : sortedHooks())
 		{
-			entry.getValue().executeEnqueuedTasks();
+			hook.executeEnqueuedTasks();
 		}
 	}
 }

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SpecialMachineBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/builder/SpecialMachineBuilder.java
@@ -106,7 +106,7 @@ public final class SpecialMachineBuilder extends MachineWithGuiBuilder<SpecialMa
 	{
 		Assert.that(isMultiblock, "Multiblock shapes can only be registered on multiblock machines");
 		Assert.notNull(shape);
-		ReiMachineRecipes.registerMultiblockShape(hook.id(name), shape, alternative);
+		hook.enqueue(() -> ReiMachineRecipes.registerMultiblockShape(hook.id(name), shape, alternative));
 		return this;
 	}
 	
@@ -134,7 +134,7 @@ public final class SpecialMachineBuilder extends MachineWithGuiBuilder<SpecialMa
 			for(var workstation : workstations)
 			{
 				Assert.notNull(workstation);
-				ReiMachineRecipes.registerWorkstation(hook.id(name), workstation);
+				hook.enqueue(() -> ReiMachineRecipes.registerWorkstation(hook.id(name), workstation));
 			}
 		}
 		return this;
@@ -143,7 +143,7 @@ public final class SpecialMachineBuilder extends MachineWithGuiBuilder<SpecialMa
 	public SpecialMachineBuilder registerAsWorkstationFor(ResourceLocation otherMachineId)
 	{
 		Assert.notNull(otherMachineId);
-		ReiMachineRecipes.registerWorkstation(otherMachineId, hook.id(name));
+		hook.enqueue(() -> ReiMachineRecipes.registerWorkstation(otherMachineId, hook.id(name)));
 		return this;
 	}
 }


### PR DESCRIPTION
Also has a hacky method to get a machine recipe type of a given ID before registries have been frozen (should only be used in extreme circumstances, like in MI Tweaks for getting recipe types for creating machines with KubeJS)