### PR TITLE
Cache config values to save on performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,8 +36,8 @@ mod_description=Another library mod for mod developers
 mod_github=https://github.com/Swedz/tesseract-neoforge
 
 # Dependencies
-tesseract_version=1.0.1
-tesseract_version_range=[1.0.1-, 1.1-)
+tesseract_version=1.0.2
+tesseract_version_range=[1.0.2-, 1.1-)
 emi_version=1.1.24+1.21.1
 modern_industrialization_version=2.5.4
 modern_industrialization_version_range=[2.5.4-, 2.6-)

--- a/src/main/java/net/swedz/tesseract/neoforge/config/ModConfigFileAccess.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/config/ModConfigFileAccess.java
@@ -1,14 +1,16 @@
 package net.swedz.tesseract.neoforge.config;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import net.swedz.tesseract.api.Assert;
 import net.swedz.tesseract.config.ConfigCodecMap;
 import net.swedz.tesseract.config.ConfigFileAccess;
+import net.swedz.tesseract.config.ConfigInstance;
 import net.swedz.tesseract.config.DefaultValueConfigHandler;
 import net.swedz.tesseract.config.annotation.ConfigComment;
 import net.swedz.tesseract.config.annotation.ConfigKey;
@@ -39,8 +41,6 @@ public final class ModConfigFileAccess implements ConfigFileAccess<Object>
 	
 	private ModConfigSpec spec;
 	
-	private final Map<String, ModConfigSpec.ConfigValue<?>> configValues = Maps.newConcurrentMap();
-	
 	public ModConfigFileAccess(ModContainer container, ModConfig.Type type, String fileName)
 	{
 		this.container = container;
@@ -63,6 +63,21 @@ public final class ModConfigFileAccess implements ConfigFileAccess<Object>
 	public ConfigCodecMap<Object> codecs()
 	{
 		return codecs;
+	}
+	
+	private void handleModConfigEvent(ModConfigEvent event, ConfigInstance<?> instance)
+	{
+		if(event.getConfig().getSpec() == spec)
+		{
+			instance.resetCache();
+		}
+	}
+	
+	public void registerReloadListeners(IEventBus bus, ConfigInstance<?> instance)
+	{
+		bus.addListener(ModConfigEvent.Loading.class, (event) -> this.handleModConfigEvent(event, instance));
+		bus.addListener(ModConfigEvent.Reloading.class, (event) -> this.handleModConfigEvent(event, instance));
+		bus.addListener(ModConfigEvent.Unloading.class, (event) -> this.handleModConfigEvent(event, instance));
 	}
 	
 	private void buildConfig(
@@ -238,13 +253,7 @@ public final class ModConfigFileAccess implements ConfigFileAccess<Object>
 	
 	private ModConfigSpec.ConfigValue<?> getConfigValue(String path)
 	{
-		ModConfigSpec.ConfigValue<?> configValue = configValues.get(path);
-		if(configValue == null)
-		{
-			configValue = spec.getValues().get(path);
-			configValues.put(path, configValue);
-		}
-		return configValue;
+		return spec.getValues().get(path);
 	}
 	
 	@Override


### PR DESCRIPTION
Relies on Swedz/tesseract#3

Mods that use `ModConfigFileAccess` should now also call the below method to ensure that caches are cleared when configs are loaded, reloaded, and unloaded.
```java
ModConfigFileAccess#registerReloadListeners(IEventBus, ConfigInstance)
```