### PR TITLE
Use a builder for common MI multiblock gui construction

### DIFF
--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/guicomponent/modularmultiblock/CommonMultiblockGuiBuilder.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/guicomponent/modularmultiblock/CommonMultiblockGuiBuilder.java
@@ -1,0 +1,142 @@
+package net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock;
+
+import aztech.modern_industrialization.MIText;
+import aztech.modern_industrialization.api.machine.component.CrafterAccess;
+import aztech.modern_industrialization.machines.components.OverclockComponent;
+import aztech.modern_industrialization.machines.components.ShapeValidComponent;
+import aztech.modern_industrialization.machines.multiblocks.MultiblockMachineBlockEntity;
+import aztech.modern_industrialization.util.TextHelper;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.swedz.tesseract.api.Assert;
+
+import java.util.List;
+
+import static net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock.ModularMultiblockGuiLine.*;
+
+public final class CommonMultiblockGuiBuilder
+{
+	private final ShapeValidComponent shapeValid;
+	
+	private CrafterAccess crafter;
+	
+	private OverclockComponent overclock;
+	
+	private int y      = 0;
+	private int height = ModularMultiblockGui.HEIGHT;
+	
+	public CommonMultiblockGuiBuilder(ShapeValidComponent shapeValid)
+	{
+		Assert.notNull(shapeValid, "ShapeValidComponent must be provided");
+		this.shapeValid = shapeValid;
+	}
+	
+	public CommonMultiblockGuiBuilder(MultiblockMachineBlockEntity machine)
+	{
+		this(machine.shapeValid);
+	}
+	
+	public CommonMultiblockGuiBuilder crafter(CrafterAccess crafter)
+	{
+		this.crafter = crafter;
+		return this;
+	}
+	
+	public CommonMultiblockGuiBuilder overclock(OverclockComponent overclock)
+	{
+		this.overclock = overclock;
+		return this;
+	}
+	
+	public CommonMultiblockGuiBuilder y(int y)
+	{
+		this.y = y;
+		return this;
+	}
+	
+	public CommonMultiblockGuiBuilder height(int height)
+	{
+		Assert.that(height > 4, String.format("Provided height outside of acceptable bounds: must be >4 but %d was provided", height));
+		this.height = height;
+		return this;
+	}
+	
+	private void contents(ModularMultiblockGuiContent content)
+	{
+		boolean isShapeValid = shapeValid.shapeValid;
+		
+		content.add((isShapeValid ? MIText.MultiblockShapeValid : MIText.MultiblockShapeInvalid).text(), isShapeValid ? WHITE : RED);
+		
+		if(isShapeValid)
+		{
+			content.add(MIText.MultiblockStatusActive.text());
+		}
+		
+		if(crafter != null && crafter.matchesMultipleRecipes())
+		{
+			content.add(MIText.MachineMultipleRecipes1.text(), RED);
+		}
+		
+		if(isShapeValid && crafter != null && crafter.hasActiveRecipe())
+		{
+			content.add(MIText.Progress.text(String.format("%.1f", crafter.getProgress() * 100) + " %"));
+			
+			if(crafter.getEfficiencyTicks() != 0 || crafter.getMaxEfficiencyTicks() != 0)
+			{
+				content.add(MIText.EfficiencyTicks.text(crafter.getEfficiencyTicks(), crafter.getMaxEfficiencyTicks()));
+			}
+			
+			content.add(MIText.BaseEuRecipe.text(TextHelper.getEuTextTick(crafter.getBaseRecipeEu())));
+			
+			content.add(MIText.CurrentEuRecipe.text(TextHelper.getEuTextTick(crafter.getCurrentRecipeEu())));
+		}
+		
+		if(overclock != null)
+		{
+			int ticks = overclock.getTicks();
+			if(ticks > 0)
+			{
+				content.add(formatOverclockText(ticks));
+			}
+		}
+	}
+	
+	private List<Component> tooltips()
+	{
+		if(crafter != null && crafter.matchesMultipleRecipes())
+		{
+			return List.of(
+					MIText.MachineMultipleRecipes1.text().withStyle(ChatFormatting.RED),
+					MIText.MachineMultipleRecipes2.text().withStyle(ChatFormatting.RED)
+			);
+		}
+		return List.of();
+	}
+	
+	public ModularMultiblockGui build()
+	{
+		return new ModularMultiblockGui(
+				y,
+				height,
+				this::contents,
+				this::tooltips
+		);
+	}
+	
+	private static Component formatOverclockText(int ticks)
+	{
+		int seconds = ticks / 20;
+		int hours = seconds / 3600;
+		int minutes = seconds % 3600 / 60;
+		String time = String.format("%d", seconds);
+		if(hours > 0)
+		{
+			time = String.format("%d:%02d:%02d", hours, minutes, seconds % 60);
+		}
+		else if(minutes > 0)
+		{
+			time = String.format("%d:%02d", minutes, seconds % 60);
+		}
+		return MIText.GunpowderTime.text(time);
+	}
+}

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/helper/CommonGuiComponents.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/helper/CommonGuiComponents.java
@@ -10,6 +10,7 @@ import aztech.modern_industrialization.util.TextHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.swedz.tesseract.neoforge.compat.mi.component.craft.ModularCrafterAccess;
+import net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock.CommonMultiblockGuiBuilder;
 import net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock.ModularMultiblockGui;
 
 import java.util.List;
@@ -40,6 +41,10 @@ public final class CommonGuiComponents
 		);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(
 			MultiblockMachineBlockEntity machine,
 			ModularCrafterAccess<?> crafter,
@@ -104,71 +109,127 @@ public final class CommonGuiComponents
 		);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, Supplier<Long> baseEuSupplier, IsActiveComponent isActive, OverclockComponent overclock)
 	{
 		return standardMultiblockScreen(machine, crafter, baseEuSupplier, isActive, overclock, 0, ModularMultiblockGui.HEIGHT);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, Supplier<Long> baseEuSupplier, IsActiveComponent isActive)
 	{
 		return standardMultiblockScreen(machine, crafter, baseEuSupplier, isActive, null, 0, ModularMultiblockGui.HEIGHT);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive, OverclockComponent overclock, int y, int height)
 	{
 		return standardMultiblockScreen(machine, crafter, crafter::getBaseRecipeEu, isActive, overclock, y, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive, int y, int height)
 	{
 		return standardMultiblockScreen(machine, crafter, crafter::getBaseRecipeEu, isActive, null, y, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive, OverclockComponent overclock, int height)
 	{
 		return standardMultiblockScreen(machine, crafter, crafter::getBaseRecipeEu, isActive, overclock, 0, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive, int height)
 	{
 		return standardMultiblockScreen(machine, crafter, crafter::getBaseRecipeEu, isActive, null, 0, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive, OverclockComponent overclock)
 	{
 		return standardMultiblockScreen(machine, crafter, isActive, overclock, ModularMultiblockGui.HEIGHT);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, ModularCrafterAccess<?> crafter, IsActiveComponent isActive)
 	{
 		return standardMultiblockScreen(machine, crafter, isActive, ModularMultiblockGui.HEIGHT);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive, OverclockComponent overclock, int y, int height)
 	{
 		return standardMultiblockScreen(machine, null, null, isActive, overclock, y, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive, int y, int height)
 	{
 		return standardMultiblockScreen(machine, null, null, isActive, null, y, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive, OverclockComponent overclock, int height)
 	{
 		return standardMultiblockScreen(machine, null, null, isActive, overclock, 0, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive, int height)
 	{
 		return standardMultiblockScreen(machine, null, null, isActive, null, 0, height);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive, OverclockComponent overclock)
 	{
 		return standardMultiblockScreen(machine, isActive, overclock, ModularMultiblockGui.HEIGHT);
 	}
 	
+	/**
+	 * @deprecated use {@link CommonMultiblockGuiBuilder}
+	 */
+	@Deprecated(since = "1.12.17", forRemoval = true)
 	public static ModularMultiblockGui standardMultiblockScreen(MultiblockMachineBlockEntity machine, IsActiveComponent isActive)
 	{
 		return standardMultiblockScreen(machine, isActive, ModularMultiblockGui.HEIGHT);

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/blockentity/multiblock/multiplied/AbstractElectricMultipliedCraftingMultiblockBlockEntity.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/blockentity/multiblock/multiplied/AbstractElectricMultipliedCraftingMultiblockBlockEntity.java
@@ -22,7 +22,7 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.swedz.tesseract.neoforge.compat.mi.TesseractMI;
 import net.swedz.tesseract.neoforge.compat.mi.api.MachineTierHolder;
-import net.swedz.tesseract.neoforge.compat.mi.helper.CommonGuiComponents;
+import net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock.CommonMultiblockGuiBuilder;
 import net.swedz.tesseract.neoforge.compat.mi.helper.ModularLubricantHelper;
 
 import java.util.List;
@@ -55,7 +55,9 @@ public abstract class AbstractElectricMultipliedCraftingMultiblockBlockEntity ex
 				.withUpgrades(upgrades)
 				.withOverdrive(overdrive));
 		
-		this.registerGuiComponent(CommonGuiComponents.standardMultiblockScreen(this, crafter, isActive));
+		this.registerGuiComponent(new CommonMultiblockGuiBuilder(this)
+				.crafter(crafter)
+				.build());
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/blockentity/multiblock/multiplied/AbstractSteamMultipliedCraftingMultiblockBlockEntity.java
+++ b/src/main/java/net/swedz/tesseract/neoforge/compat/mi/machine/blockentity/multiblock/multiplied/AbstractSteamMultipliedCraftingMultiblockBlockEntity.java
@@ -16,7 +16,7 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.swedz.tesseract.neoforge.compat.mi.TesseractMI;
 import net.swedz.tesseract.neoforge.compat.mi.api.SteamMachineTierHolder;
-import net.swedz.tesseract.neoforge.compat.mi.helper.CommonGuiComponents;
+import net.swedz.tesseract.neoforge.compat.mi.guicomponent.modularmultiblock.CommonMultiblockGuiBuilder;
 
 import java.util.List;
 
@@ -35,7 +35,10 @@ public abstract class AbstractSteamMultipliedCraftingMultiblockBlockEntity exten
 		
 		this.registerComponents(overclock);
 		
-		this.registerGuiComponent(CommonGuiComponents.standardMultiblockScreen(this, crafter, isActive, overclock));
+		this.registerGuiComponent(new CommonMultiblockGuiBuilder(this)
+				.crafter(crafter)
+				.overclock(overclock)
+				.build());
 	}
 	
 	@Override


### PR DESCRIPTION
A lot of the methods in `CommonGuiComponents` are deprecated now in favor of the `CommonMultiblockGuiBuilder`. These deprecated methods will be removed in the next major version release of Tesseract API.